### PR TITLE
Fixes metric collection scripts to cover the cases when an app sets u…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Added
 - Rakefile now inclutes kitchen integration tests
+- Fixes metric collection scripts to cover the cases when an app sets unit as ""
 
 ### [0.0.3] - 2017-08-12
 ### Changed

--- a/bin/metrics-dcos-containers.rb
+++ b/bin/metrics-dcos-containers.rb
@@ -99,6 +99,7 @@ class DCOSMetrics < Sensu::Plugin::Metric::CLI::Graphite
           end
           metric['name'].tr!('/', '.')
           metric['name'].squeeze!('.')
+          metric['unit'] = 'na' if metric['unit'].empty?
           output([config[:scheme], container, 'app', metric['unit'], metric['name']].join('.'), metric['value'])
         end
       end

--- a/bin/metrics-dcos-host.rb
+++ b/bin/metrics-dcos-host.rb
@@ -88,6 +88,7 @@ class DCOSMetrics < Sensu::Plugin::Metric::CLI::Graphite
         end
         metric['name'].tr!('/', '.')
         metric['name'].squeeze!('.')
+        metric['unit'] = 'na' if metric['unit'].empty?
         output([config[:scheme], metric['unit'], metric['name']].join('.'), metric['value'])
       end
     end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

Some frameworks are setting the metric unit as a empty string and this causes the metric name to be broken.

#### Known Compatibility Issues

