### PR TITLE
added option to output framework name in container metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,7 @@ This CHANGELOG follows the format listed at [Our CHANGELOG Guidelines ](https://
 Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
-
-## [0.3.1] - 2017-09-10
-## Added
+### Added
 - todo item is added: metrics-dcos-containers.rb Add dimentions to the metric name framework_name, framework_role, executor_id (@1fox1)
 - added dimensions argument, argument takes a comma seperated list of the dimensions you wish to output (@1fox1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
 
+## [0.3.1] - 2017-09-10
+## Added
+- todo item is added: metrics-dcos-containers.rb Add dimentions to the metric name framework_name, framework_role, executor_id (@1fox1)
+- added dimensions argument, argument takes a comma seperated list of the dimensions you wish to output (@1fox1)
+
 ## [0.3.0] - 2017-09-19
 ### Added
 - started re-testing all supported ruby versions again (@majormoses)

--- a/README.md
+++ b/README.md
@@ -9,12 +9,16 @@
 ## Functionality
 
 ## Files
- * bin/check-dcos-metrics.rb
- * check-dcos-container-metrics.rb
- * bin/check-dcos-container-count.rb
- * bin/check-dcos-metrics.rb
- * bin/check-dcos-ping.rb
  * bin/check-dcos-component-health.rb
+ * bin/check-dcos-container-count.rb
+ * bin/check-dcos-container-metrics.rb
+ * bin/check-dcos-jobs-health.rb
+ * bin/check-dcos-metrics.rb
+ * bin/check-dcos-node-health.rb
+ * bin/check-dcos-ping.rb
+ * bin/metrics-dcos-containers.rb
+ * bin/metrics-dcos-host.rb
+ * bin/metrics-dcos-system-health.rb
 
 ## Usage
 
@@ -58,6 +62,9 @@ This is an example how to use this plugin to ship metrics to InfluxDB using the 
   }
 }
 ```
+
+metrics-dcos-containers.rb can be used in the same way to ship container metrics (from frameworks not apps) specify a comma seperated list of the dimensions you require in the oupput to the --dimensions flag. example metrics-dcos-containers.rb --dimensions 'framework_name,excutor_id'  
+
 
 ### Host Health Check
 


### PR DESCRIPTION
## Pull Request Checklist

- todo item is added : metrics-dcos-containers.rb Add dimensions to the metric name framework_name, framework_role, executor_id

- added dimensions argument, argument takes a comma separated list of the dimensions you wish to have in the output

#### General

- [x] Update Changelog following the conventions laid out on [Our CHANGELOG Guidelines ](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose

This change will allow us to differentiate between multiple instances of the same framework in dashboards.

#### Known Compatibility Issues

None