### PR TITLE
correctly handle metrics even if container metrics are not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ This CHANGELOG follows the format listed at [Our CHANGELOG Guidelines ](https://
 Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
-### Changed
-- fixes the handling of empty container metrics issue from dcos-metrics
+### Fixed
+- fixed the handling of empty container metrics issue from dcos-metrics
 
 ## [0.4.0] - 2017-10-20
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This CHANGELOG follows the format listed at [Our CHANGELOG Guidelines ](https://
 Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Changed
+- fixes the handling of empty container metrics issue from dcos-metrics
 
 ## [0.4.0] - 2017-10-20
 ### Added

--- a/bin/metrics-dcos-containers.rb
+++ b/bin/metrics-dcos-containers.rb
@@ -93,20 +93,20 @@ class DCOSMetrics < Sensu::Plugin::Metric::CLI::Graphite
          long: '--dimensions DIMENSIONS',
          required: false
 
-  def frameworks
+  def mesos_frameworks
     # Return the memoized result if exists. This will ensure that the mesos
     # state endpoint will be called only once and when needed and return the
     # cached result immediately for subsequent calls.
-    return @frameworks if @frameworks
+    return @mesos_frameworks if @mesos_frameworks
     agent_ip = `#{config[:agent_ip_discovery_command]}`
-    state = get_data("http://#{agent_ip}:#{config[:agent_port]}/slave(1)/state")
-    @frameworks = {}
+    state = get_data("http://#{agent_ip}:#{config[:agent_port]}/state")
+    @mesos_frameworks = {}
     %w[frameworks completed_frameworks].each do |fw_key|
       state[fw_key].each do |framework|
-        @frameworks[framework['id']] = framework['name']
+        @mesos_frameworks[framework['id']] = framework['name']
       end
     end
-    @frameworks
+    @mesos_frameworks
   end
 
   def get_extra_tags(dimensions)
@@ -118,7 +118,7 @@ class DCOSMetrics < Sensu::Plugin::Metric::CLI::Graphite
       # available, see https://jira.mesosphere.com/browse/DCOS_OSS-2043 for
       # upstream issue.
       if d == 'framework_name' && !dimensions.key?('framework_name')
-        extra_tags.push(frameworks[dimensions['framework_id']])
+        extra_tags.push(mesos_frameworks[dimensions['framework_id']])
       else
         extra_tags.push(dimensions[d])
       end

--- a/bin/metrics-dcos-containers.rb
+++ b/bin/metrics-dcos-containers.rb
@@ -69,6 +69,18 @@ class DCOSMetrics < Sensu::Plugin::Metric::CLI::Graphite
          required: false,
          default: '61001'
 
+  option :agent_host,
+         description: 'DCOS agent host',
+         long: '--agent-host PORT',
+         required: false,
+         default: `/opt/mesosphere/bin/detect_ip`
+
+  option :agent_port,
+         description: 'DCOS agent port',
+         long: '--agent-port PORT',
+         required: false,
+         default: '5051'
+
   option :uri,
          description: 'Endpoint URI',
          short: '-u URI',
@@ -81,20 +93,46 @@ class DCOSMetrics < Sensu::Plugin::Metric::CLI::Graphite
          long: '--dimensions DIMENSIONS',
          required: false
 
+  def frameworks
+    # Return the memoized result if exists. This will ensure that the mesos
+    # state endpoint will be called only once and when needed and return the
+    # cached result immediately for subsequent calls.
+    return @frameworks if @frameworks
+    state = get_data("http://#{config[:agent_host]}:#{config[:agent_port]}/slave(1)/state")
+    @frameworks = {}
+    %w[frameworks completed_frameworks].each do |fw_key|
+      state[fw_key].each do |framework|
+        @frameworks[framework['id']] = framework['name']
+      end
+    end
+    @frameworks
+  end
+
+  def get_extra_tags(dimensions)
+    extra_tags = []
+    return extra_tags unless config[:dimensions]
+    config[:dimensions].tr(' ', '').split(',').each do |d|
+      # Special case for app metrics, framework_name dimension does not exist
+      # in app metrics and in some cases app metrics/dimensions are not
+      # available, see https://jira.mesosphere.com/browse/DCOS_OSS-2043 for
+      # upstream issue.
+      if d == 'framework_name' && !dimensions.key?('framework_name')
+        extra_tags.push(frameworks[dimensions['framework_id']])
+      else
+        extra_tags.push(dimensions[d])
+      end
+    end
+    extra_tags
+  end
+
   def run
     containers = get_data("http://#{config[:server]}:#{config[:port]}#{config[:uri]}")
     unless containers.nil? || containers.empty?
-      containers.each do |container| # rubocop:disable Metrics/BlockLength
-        all_metrics = get_data("http://#{config[:server]}:#{config[:port]}#{config[:uri]}/#{container}")
-        next if all_metrics.empty?
-        if config[:dimensions]
-          extra_tags = []
-          config[:dimensions].tr(' ', '').split(',').each do |d|
-            extra_tags.push(all_metrics['dimensions'][d]) if all_metrics['dimensions'][d]
-          end
-        end
-        if all_metrics.key?('datapoints')
-          all_metrics['datapoints'].each do |metric|
+      containers.each do |container|
+        container_metrics = get_data("http://#{config[:server]}:#{config[:port]}#{config[:uri]}/#{container}")
+        if container_metrics.key?('datapoints')
+          extra_tags = get_extra_tags(container_metrics['dimensions'])
+          container_metrics['datapoints'].each do |metric|
             metric['name'].tr!('/', '.')
             metric['name'].squeeze!('.')
             output([config[:scheme], extra_tags, container, metric['unit'], metric['name']].compact.join('.'), metric['value'])
@@ -102,6 +140,10 @@ class DCOSMetrics < Sensu::Plugin::Metric::CLI::Graphite
         end
         app_metrics = get_data("http://#{config[:server]}:#{config[:port]}#{config[:uri]}/#{container}/app")
         next if app_metrics['datapoints'].nil?
+        app_dimensions = app_metrics['dimensions']
+        # merge container dimensions into app dimensions since app dimensions does have less
+        app_dimensions = container_metrics['dimensions'].merge(app_dimensions) if container_metrics.key?('dimensions')
+        extra_tags = get_extra_tags(app_dimensions)
         app_metrics['datapoints'].each do |metric|
           unless metric['tags'].nil?
             metric['tags'].each do |k, v|

--- a/bin/metrics-dcos-containers.rb
+++ b/bin/metrics-dcos-containers.rb
@@ -86,6 +86,7 @@ class DCOSMetrics < Sensu::Plugin::Metric::CLI::Graphite
     unless containers.nil? || containers.empty?
       containers.each do |container| # rubocop:disable Metrics/BlockLength
         all_metrics = get_data("http://#{config[:server]}:#{config[:port]}#{config[:uri]}/#{container}")
+        next if all_metrics.empty?
         if config[:dimensions]
           extra_tags = []
           config[:dimensions].tr(' ', '').split(',').each do |d|

--- a/bin/metrics-dcos-containers.rb
+++ b/bin/metrics-dcos-containers.rb
@@ -69,11 +69,11 @@ class DCOSMetrics < Sensu::Plugin::Metric::CLI::Graphite
          required: false,
          default: '61001'
 
-  option :agent_host,
-         description: 'DCOS agent host',
-         long: '--agent-host PORT',
+  option :agent_ip_discovery_command,
+         description: 'DCOS agent ip discovery command',
+         long: '--agent-ip-discovery-command COMMAND',
          required: false,
-         default: `/opt/mesosphere/bin/detect_ip`
+         default: '/opt/mesosphere/bin/detect_ip'
 
   option :agent_port,
          description: 'DCOS agent port',
@@ -98,7 +98,8 @@ class DCOSMetrics < Sensu::Plugin::Metric::CLI::Graphite
     # state endpoint will be called only once and when needed and return the
     # cached result immediately for subsequent calls.
     return @frameworks if @frameworks
-    state = get_data("http://#{config[:agent_host]}:#{config[:agent_port]}/slave(1)/state")
+    agent_ip = `#{config[:agent_ip_discovery_command]}`
+    state = get_data("http://#{agent_ip}:#{config[:agent_port]}/slave(1)/state")
     @frameworks = {}
     %w[frameworks completed_frameworks].each do |fw_key|
       state[fw_key].each do |framework|


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
No

#### General

- [x] Update Changelog following the conventions laid out on [Our CHANGELOG Guidelines ](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
No update needed.

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose
We updated our clusters to dcos 1.10.1 and suddenly our framework metrics vanished, i found that some containers does not expose any metrics but they are listed in containers endpoint.

The metrics script doesn't expect this to happen and panics out with this stack:
```
[centos@ip-10-0-18-87 ~]$ /opt/sensu/embedded/bin/metrics-dcos-containers.rb -d 'framework_name,executor_id'
Check failed to run: undefined method `[]' for nil:NilClass, ["/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/sensu-plugins-dcos-0.4.0/bin/metrics-dcos-containers.rb:93:in `block (2 levels) in run'", "/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/sensu-plugins-dcos-0.4.0/bin/metrics-dcos-containers.rb:92:in `each'", "/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/sensu-plugins-dcos-0.4.0/bin/metrics-dcos-containers.rb:92:in `block in run'", "/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/sensu-plugins-dcos-0.4.0/bin/metrics-dcos-containers.rb:87:in `each'", "/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/sensu-plugins-dcos-0.4.0/bin/metrics-dcos-containers.rb:87:in `run'", "/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/sensu-plugin-1.4.5/lib/sensu-plugin/cli.rb:58:in `block in <class:CLI>'"]
[centos@ip-10-0-18-87 ~]$ 
```

#### Known Compatibility Issues
None